### PR TITLE
fix: add static return type for paginate

### DIFF
--- a/lib/KirbyLoupeCollection.php
+++ b/lib/KirbyLoupeCollection.php
@@ -37,7 +37,7 @@ class KirbyLoupeCollection extends Collection {
     return $this->hit($page)["_formatted"];
   }
 
-  public function paginate(...$arguments) {
+  public function paginate(...$arguments): static {
     // The original Collection class uses Pagination::for() which will
     // automatically set the total parameter based on the collection length
     // which we don't want, so we create new Pagination instance manually.


### PR DESCRIPTION
Kirby 5 introduces a lot of return types. To be compatible with Kirby's Collection class, the KirbyLoupeCollection class also needs to return the static return type on the `paginate()` method.

See: https://github.com/getkirby/kirby/blob/ddd11f9b4a23e0b5d306b146ca5d6b7a1c1909a9/src/Cms/Collection.php#L267